### PR TITLE
Add Tutor Search Filter

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django_filters',
     'rest_framework',
     'annoying',
     'swpp'

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ python-coveralls
 coverage
 django-registration-redux
 django-registration-defaults
+django-filter

--- a/backend/swpp/view/tutor.py
+++ b/backend/swpp/view/tutor.py
@@ -3,10 +3,19 @@ from swpp.models import Tutor
 from swpp.serializers import TutorSerializer
 from swpp.permissions import IsOwnerOrReadOnly
 from rest_framework import generics
+from django_filters.rest_framework import DjangoFilterBackend
+
+class TutorFilterBackend(DjangoFilterBackend):
+    def filter_queryset(self, request, queryset, view):
+        req_bio = request.GET['bio'] if ('bio' in request.GET) else '';
+        req_exp = request.GET['exp'] if ('exp' in request.GET) else '';
+        return queryset.filter(bio__icontains=req_bio, exp__icontains=req_exp)
 
 class TutorList(generics.ListAPIView):
     queryset = Tutor.objects.all()
     serializer_class = TutorSerializer
+    filter_backends = (TutorFilterBackend,)
+    filterset_fields = ('bio', 'exp')
 
 class TutorDetails(generics.RetrieveUpdateAPIView):
     permission_classes = (IsOwnerOrReadOnly,)


### PR DESCRIPTION
튜터 목록을 GET 할 때 bio와 exp에 대해 parameter를 넘겨주면
해당 문자열이 포함된 튜터만 보여지게 했습니다.
(예시) /tutors/?bio=bb&exp=ee

bio와 exp말고도 profile의 major 등 다른 추가요소를 생각해보면 좋을 것 같습니다.
#36 