### PR TITLE
Enabled filtering of tutors based on times

### DIFF
--- a/backend/swpp/model/times.py
+++ b/backend/swpp/model/times.py
@@ -9,3 +9,27 @@ class Times(models.Model):
     fri = models.BigIntegerField(default = 0)
     sat = models.BigIntegerField(default = 0)
     sun = models.BigIntegerField(default = 0)
+
+    # minInterval, total: 1 per 30 min. ex) 4 = 2 hrs
+    def isAvailable(self, other, minInterval, total):
+        mon = self.mon & other.data['mon']
+        tue = self.tue & other.data['tue']
+        wed = self.wed & other.data['wed']
+        thu = self.thu & other.data['thu']
+        fri = self.fri & other.data['fri']
+        sat = self.sat & other.data['sat']
+        sun = self.sun & other.data['sun']
+
+        available = 0
+
+        for time in [mon, tue, wed, thu, fri, sat, sun]:
+            combo = 0
+            while time:
+                if time & 1: combo += 1
+                else:
+                    if combo >= minInterval: available += combo
+                    combo = 0
+                time >>= 1
+            if combo >= minInterval: available += combo
+
+        return available >= total

--- a/backend/swpp/urls.py
+++ b/backend/swpp/urls.py
@@ -8,5 +8,6 @@ urlpatterns = [
     path('profiles/', views.ProfileList.as_view()),
     path('profile/<int:pk>/', views.ProfileDetails.as_view()),
     path('tutors/', views.TutorList.as_view()),
-    path('tutor/<int:pk>/', views.TutorDetails.as_view())
+    path('tutor/<int:pk>/', views.TutorDetails.as_view()),
+    path('times/<int:pk>/', views.TimesDetails.as_view())
 ]

--- a/backend/swpp/view/profile.py
+++ b/backend/swpp/view/profile.py
@@ -1,9 +1,7 @@
 from django.shortcuts import render
 from swpp.models import Profile
 from swpp.serializers import ProfileSerializer
-from rest_framework import generics
-from rest_framework import mixins
-from rest_framework import permissions
+from rest_framework import generics, mixins, permissions
 from swpp.permissions import IsOwnerOrReadOnly
 
 class ProfileList(generics.ListAPIView):

--- a/backend/swpp/view/times.py
+++ b/backend/swpp/view/times.py
@@ -1,12 +1,16 @@
 from django.shortcuts import render
 from swpp.models import Times
 from swpp.serializers import TimesSerializer
-from rest_framework import generics
+from rest_framework import generics, mixins
 
 class TimesList(generics.ListAPIView):
     queryset = Times.objects.all()
     serializer_class = TimesSerializer
 
-class TimesDetails(generics.RetrieveAPIView):
+class TimesDetails(generics.RetrieveAPIView,
+                   mixins.UpdateModelMixin):
     queryset = Times.objects.all()
     serializer_class = TimesSerializer
+
+    def put(self, request, *args, **kwargs):
+        return self.update(request, *args, **kwargs)


### PR DESCRIPTION
시간대 정보를 이용하여 가능한 튜터를 필터링하는 기능을 구현하였습니다.

**mon, tue, wed, thu, fri, sat, sun** 파라미터에 48비트 이진수 시간대(16진법으로 encoding 권장)를, 최소 세션 길이인 **minInterval** 파라미터에 자연수를(30분당 1, 기본값 1), **total** 파라미터에 자연수를(30분당 1) 넣고 url을 생성하여 /tutors/에 get request를 생성하면 됩니다.

예를 들어 월요일 4시부터 7시에 가능하고, minInterval이 2(세션이 최소 1시간)이며 total이 4(주 최소 2시간)인 request의 경우, 월요일 4시부터 5시와 6시부터 7시에 가능한 튜터는 검색이 될 것이고, 월요일 5시 반부터 7시에 가능한 튜터나 월요일에 가능하지 않은 튜터는 검색되지 않을 것입니다.

이에 대한 테스트 케이스도 몇 가지 첨부하였으나, 추가적인 검증이 필요하다고 생각되는 경우 알려 주시기 바랍니다.