### PR TITLE
[긴급] npm 'uncontrollable' 패키지 upstream 버그 우회

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2043,6 +2043,14 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
     },
+    "@primer/octicons-react": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-9.0.0.tgz",
+      "integrity": "sha512-pzklnlyRWugBjejAcp5OPJ6RclMJzDxXk95FyuxzFT0dMg8GHWq0oJbrIkX3b1rWiF04jKkHk7r8oKbKLwcF+Q==",
+      "requires": {
+        "prop-types": "^15.6.1"
+      }
+    },
     "@reach/router": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@reach/router/-/router-1.2.1.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -128,7 +128,7 @@
     "styled-components": "^4.3.1",
     "styled-theme": "^0.3.3",
     "styled-tools": "^1.7.1",
-    "uncontrollable": "^6.1.0",
+    "uncontrollable": "6.1.0",
     "validator": "^11.0.0"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -97,6 +97,7 @@
     "webpack-md5-hash": "^0.0.6"
   },
   "dependencies": {
+    "@primer/octicons-react": "^9.0.0",
     "babel-polyfill": "^6.26.0",
     "bootstrap": "^4.3.1",
     "color": "^3.1.2",
@@ -127,6 +128,7 @@
     "styled-components": "^4.3.1",
     "styled-theme": "^0.3.3",
     "styled-tools": "^1.7.1",
+    "uncontrollable": "^6.1.0",
     "validator": "^11.0.0"
   }
 }


### PR DESCRIPTION
npm uncontrollable 패키지의 개발자들이 새 버전을 제대로 publish하지 않는 바람에 그에 dependency를 가진 수많은 npm 패키지들이 모두 터지게 되었습니다.
이를 우회하기 위해 uncontrollable 패키지의 버전을 구 버전으로 설정했습니다.